### PR TITLE
 Add support for exposing the docker remote API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform module to provision and bootstrap a Docker Swarm mode cluster with mul
 
 ## Requirements
 
-- Terraform >= 0.11.2
+- Terraform >= 0.11.7
 - Digitalocean account / API token with write access
 - SSH Keys added to your DigitalOcean account
 - [jq](https://github.com/stedolan/jq)
@@ -19,17 +19,41 @@ Terraform module to provision and bootstrap a Docker Swarm mode cluster with mul
 
 ```hcl
 module "swarm-cluster" {
-  source          = "github.com/thojkooi/terraform-digitalocean-swarm-managers"
+  source          = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.2.0"
   domain          = "do.example.com"
   total_instances = 3
-  do_token        = "${var.do_token}"
   ssh_keys        = [1234, 1235, ...]
+  providers {}
 }
 ```
 
 ### SSH Key
 
 Terraform uses an SSH key to connect to the created droplets in order to issue `docker swarm join` commands. By default this uses `~/.ssh/id_rsa`. If you wish to use a different key, you can modify this using the variable `provision_ssh_key`. You also need to ensure the public key is added to your DigitalOcean account and it's ID is listed in the `ssh_keys` list.
+
+### Exposing the Docker API
+
+You can expose the Docker API to interact with the cluster remotely. This is done by providing a certificate and private key. See the [Docker TLS example](https://github.com/thojkooi/terraform-digitalocean-swarm-managers/tree/master/examples/remote-api-tls).
+
+```hcl
+module "swarm_mode_cluster" {
+  source          = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.3.0"
+
+  domain          = "do.example.com"
+  total_instances = 3
+  ssh_keys        = [1234, 1235, ...]
+
+  remote_api_ca          = "${path.module}/certs/ca.pem"
+  remote_api_certificate = "${path.module}/certs/server.pem"
+  remote_api_key         = "${path.module}/certs/server-key.pem"
+
+  size = "s-2vcpu-4gb"
+
+  tags = ["${digitalocean_tag.cluster.id}", "${digitalocean_tag.manager.id}"]
+
+  providers = {}
+}
+```
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can expose the Docker API to interact with the cluster remotely. This is don
 
 ```hcl
 module "swarm_mode_cluster" {
-  source          = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.3.0"
+  source          = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=v0.2.0"
 
   domain          = "do.example.com"
   total_instances = 3

--- a/examples/add-workers/main.tf
+++ b/examples/add-workers/main.tf
@@ -29,7 +29,7 @@ module "workers" {
   total_instances = 1
   ssh_keys        = "${var.ssh_keys}"
 
-  manager_public_ip  = "${module.swarm-cluster-managers.ipv4_addresses[0]}"
-  manager_private_ip = "${module.swarm-cluster-managers.ipv4_addresses_private[0]}"
+  manager_public_ip  = "${element(module.swarm-cluster-managers.ipv4_addresses, 0)}"
+  manager_private_ip = "${element(module.swarm-cluster-managers.ipv4_addresses_private, 0)}"
   join_token         = "${module.swarm-cluster-managers.worker_token}"
 }

--- a/examples/remote-api-tls/README.md
+++ b/examples/remote-api-tls/README.md
@@ -1,0 +1,57 @@
+# Remote API TLS
+
+Create managers and expose the Docker Remote API over TLS.
+
+For this, you need to create certificates and keys.
+
+### Creating CA and server certificates
+
+This is an example using cfssl, following the [CoreOS self signed certificates](https://coreos.com/os/docs/latest/generate-self-signed-certificates.html) docs.
+
+More references can be found:
+
+- https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+- https://docs.docker.com/engine/security/https/#create-a-ca-server-and-client-keys-with-openssl
+
+
+```bash
+echo '{"CN":"CA","key":{"algo":"rsa","size":4096}}' | cfssl gencert -initca - | cfssljson -bare ca -
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
+export ADDRESS=example.com
+export NAME=server
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+```
+
+Upgrade the `ADDRESS` variable to match the host name / address used to access the Docker API.
+
+### Create the client certificates
+
+```bash
+export ADDRESS=
+export NAME=client
+echo '{"CN":"'$NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem -hostname="$ADDRESS" - | cfssljson -bare $NAME
+```
+
+### Create the managers
+
+```
+$ terraform apply
+
+data.template_file.provision_manager: Refreshing state...
+data.template_file.provision_first_manager: Refreshing state...
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+ <= read (data resources)
+....
+Plan: 18 to add, 0 to change, 0 to destroy.
+
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value:
+```
+
+You can use the client certificates to access the docker api.

--- a/examples/remote-api-tls/main.tf
+++ b/examples/remote-api-tls/main.tf
@@ -1,0 +1,55 @@
+variable "do_token" {}
+
+variable "ssh_keys" {
+  type = "list"
+}
+
+provider "digitalocean" {
+  token = "${var.do_token}"
+}
+
+resource "digitalocean_tag" "manager" {
+  name = "swarm-mode-manager"
+}
+
+module "managers" {
+  source = "github.com/thojkooi/terraform-digitalocean-swarm-managers?ref=support-remote-api"
+
+  domain          = "do.example.com"
+  total_instances = 3
+  ssh_keys        = ["${var.ssh_keys}"]
+
+  remote_api_ca          = "${path.module}/ca.pem"
+  remote_api_certificate = "${path.module}/server.pem"
+  remote_api_key         = "${path.module}/server-key.pem"
+
+  size = "s-2vcpu-4gb"
+
+  tags = ["${digitalocean_tag.manager.id}"]
+
+  providers = {}
+}
+
+module "basic-fw-rules" {
+  source  = "thojkooi/firewall-rules/digitalocean"
+  version = "1.0.0"
+
+  prefix = "do-example-com"
+  tags   = ["${digitalocean_tag.manager.id}"]
+}
+
+module "api-access-firewall" {
+  source                   = "github.com/thojkooi/terraform-digitalocean-firewall-docker-api?ref=v0.1.2"
+  prefix                   = "do-example-com"
+  tags                     = ["${digitalocean_tag.manager.id}"]
+  api_access_from_adresses = ["0.0.0.0/0", "::/0"]
+}
+
+module "swarm-mode-firewall" {
+  source  = "thojkooi/docker-swarm-firewall/digitalocean"
+  version = "1.0.0"
+
+  prefix              = "do-example-com"
+  cluster_droplet_ids = []
+  cluster_tags        = ["${digitalocean_tag.manager.id}"]
+}

--- a/examples/user-data/main.tf
+++ b/examples/user-data/main.tf
@@ -16,15 +16,10 @@ resource "digitalocean_tag" "manager" {
   name = "manager"
 }
 
-resource "digitalocean_tag" "worker" {
-  name = "worker"
-}
-
 module "swarm-cluster-managers" {
   source          = "../../"
   total_instances = 1
   domain          = "do.example.com"
-  do_token        = "${var.do_token}"
   ssh_keys        = "${var.ssh_keys}"
   image           = "centos-7-x64"
   provision_user  = "root"

--- a/examples/user-data/scripts/install-docker-ce.sh
+++ b/examples/user-data/scripts/install-docker-ce.sh
@@ -14,4 +14,5 @@ yum -y install docker-ce
 
 sleep 1;
 
+systemctl enable docker
 systemctl start docker

--- a/scripts/certs/coreos.sh
+++ b/scripts/certs/coreos.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Install certificates for the Docker Remote API
+# Based on:
+# - https://coreos.com/os/docs/latest/customizing-docker.html
+# - https://docs.docker.com/engine/reference/commandline/dockerd/
+# -https://docs.docker.com/engine/security/https/#secure-by-default
+
+sudo systemctl stop docker
+sudo systemctl disable docker
+
+sudo mkdir -p /var/ssl
+sudo mv ~/.docker/{server-cert.pem,server-key.pem,ca.pem} /var/ssl/
+
+sudo cat<<-EOF > /etc/systemd/system/docker-tls-tcp.socket
+[Unit]
+Description=Docker Secured Socket for the API
+
+[Socket]
+ListenStream=2376
+BindIPv6Only=both
+Service=docker.service
+
+[Install]
+WantedBy=sockets.target
+EOF
+
+sudo systemctl enable docker-tls-tcp.socket
+sudo systemctl stop docker
+sudo systemctl start docker-tls-tcp.socket
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo cat<<-EOF > /etc/systemd/system/docker.service.d/10-tls-verify.conf
+[Service]
+Environment="DOCKER_OPTS=--tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem"
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker.service

--- a/scripts/certs/default.sh
+++ b/scripts/certs/default.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sudo mkdir -p /var/ssl
+sudo mv ~/.docker/{server-cert.pem,server-key.pem,ca.pem} /var/ssl/
+
+sudo mkdir -p /etc/systemd/system/docker.service.d
+sudo bash -c 'cat<<-EOF > /etc/systemd/system/docker.service.d/10-tls-verify.conf
+[Service]
+Environment="DOCKER_OPTS=--tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem"
+ExecStart=
+ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376 -H unix://var/run/docker.sock --tlsverify=true --tlscacert=/var/ssl/ca.pem --tlscert=/var/ssl/server-cert.pem --tlskey=/var/ssl/server-key.pem
+EOF'
+
+sudo systemctl daemon-reload
+sudo systemctl restart docker

--- a/scripts/get-swarm-join-tokens.sh
+++ b/scripts/get-swarm-join-tokens.sh
@@ -4,17 +4,16 @@
 # https://www.terraform.io/docs/providers/external/data_source.html#processing-json-in-shell-scripts
 # Credits to https://github.com/knpwrs/docker-swarm-terraform for inspiration on how to do this
 
-set -e
 eval "$(jq -r '@sh "HOST=\(.host) USER=\(.user) PRIVATE_KEY=\(.private_key)"')"
 
 # Fetch the manager join token
 MANAGER=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PRIVATE_KEY \
-    $USER@$HOST docker swarm join-token manager -q)
+    $USER@$HOST timeout 5 docker swarm join-token manager -q)
 
 # Fetch the worker join token
 WORKER=$(ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $PRIVATE_KEY \
-    $USER@$HOST docker swarm join-token worker -q)
+    $USER@$HOST timeout 5 docker swarm join-token worker -q)
 
 # Produce a JSON object containing the tokens
-jq -n --arg manager "$MANAGER" --arg worker "$WORKER" \
+jq -n --arg manager "${MANAGER}" --arg worker "$WORKER" \
     '{"manager":$manager,"worker":$worker}'

--- a/scripts/provision-first-manager.sh
+++ b/scripts/provision-first-manager.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+MANAGER_PRIVATE_ADDR=$1
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+${docker_cmd} swarm init --advertise-addr $MANAGER_PRIVATE_ADDR

--- a/scripts/provision-manager.sh
+++ b/scripts/provision-manager.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+MANAGER_PRIVATE_ADDR=$1
+JOIN_TOKEN=$2
+
+# Wait until Docker is running correctly
+while [ -z "$(${docker_cmd} info | grep CPUs)" ]; do
+  echo Waiting for Docker to start...
+  sleep 2
+done
+
+# Check if we are not already joined into a Swarm
+if [ -z "$(${docker_cmd} info | grep 'Swarm: active')" ]; then
+  # Join cluster
+  ${docker_cmd} swarm join --token $JOIN_TOKEN $MANAGER_PRIVATE_ADDR:2377;
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "do_token" {
-  description = "DigitalOcean API token with read/write permissions"
-}
-
 variable "domain" {
   description = "Domain name used in droplet hostnames, e.g example.com"
 }
@@ -65,4 +61,21 @@ variable "tags" {
   description = "List of DigitalOcean tag ids"
   default     = []
   type        = "list"
+}
+
+variable "availability" {
+  description = "Availability of the node ('active'|'pause'|'drain')"
+  default     = "active"
+}
+
+variable "remote_api_ca" {
+  default = ""
+}
+
+variable "remote_api_key" {
+  default = ""
+}
+
+variable "remote_api_certificate" {
+  default = ""
 }


### PR DESCRIPTION
- Support exposing the Docker Remote API using TLS when certificates are provided
- Add support for setting availability of the manager nodes on provisioning
- Add timeout to docker join and docker leave commands. Avoid long waiting time in case a host cannot be reached
- Add docker leave command when destroying a manager node, allows for down-scaling the amount of managers
- Fix some issues with docker join bash scripting
